### PR TITLE
false pos illegal scm repo

### DIFF
--- a/app/endpoint/RepoWS.scala
+++ b/app/endpoint/RepoWS.scala
@@ -74,8 +74,9 @@ class RepoWS @Inject() (searchService: Search, repoRepository: RepoRepository) e
             logger.info(s"Not found in DB, fallback to check in SCM for repo: $url")
             searchService.isRepo(host, project, repo) flatMap {
               case Right(true) =>
-                logger.info(s"Result: 200 repo found in SCM $url")
-                Future.successful(Repository.fromUHPR(url, host, project, repo))
+                val result = Repository.fromUHPR(url, host, project, repo)
+                logger.info(s"Result: 200 repo found in SCM ${Json.toJson(result)}")
+                Future.successful(Ok(Json.toJson(result)).as("application/x.zalando.repository+json"))
               case _           =>
                 logger.info(s"Result: 404 repo not found $url")
                 Future.successful(NotFound)

--- a/app/endpoint/RepoWS.scala
+++ b/app/endpoint/RepoWS.scala
@@ -15,6 +15,7 @@ import java.net.URLEncoder
 import scala.concurrent.future
 import scala.concurrent.Future
 import model.RepositoryResult
+import model.Repository
 import model.KontrollettiToJsonParser._
 import dao.RepoRepository
 import scala.util.Try
@@ -65,13 +66,20 @@ class RepoWS @Inject() (searchService: Search, repoRepository: RepoRepository) e
 
     searchService.parse(url) match {
       case Right((host, project, repo)) =>
-        repoRepository.byParameters(host, project, repo).map {
+        repoRepository.byParameters(host, project, repo) flatMap {
           case Some(result) =>
             logger.info(s"Result: 200 " + Json.toJson(result))
-            Ok(Json.toJson(result)).as("application/x.zalando.repository+json")
+            Future.successful(Ok(Json.toJson(result)).as("application/x.zalando.repository+json"))
           case None =>
-            logger.info(s"Result: 404 ")
-            NotFound
+            logger.info(s"Not found in DB, fallback to check in SCM for repo: $url")
+            searchService.isRepo(host, project, repo) flatMap {
+              case Right(true) =>
+                logger.info(s"Result: 200 repo found in SCM $url")
+                Future.successful(Repository.fromUHPR(url, host, project, repo))
+              case _           =>
+                logger.info(s"Result: 404 repo not found $url")
+                Future.successful(NotFound)
+            }
         }
       case Left(error) =>
         logger.info(s"Result: 400 $error")

--- a/app/model/Model.scala
+++ b/app/model/Model.scala
@@ -25,6 +25,11 @@ object Commit {
   def numberOfParents(c: Commit): Int = sizeOfOptionList(c.parentIds)
   def isValid(c: Commit): Boolean = numberOfTickets(c) > 0 || numberOfParents(c) > 1
 }
+
+object Repository {
+  def fromUHPR(url: String, host: String, project: String, repository: String) =
+    Repository(url, host, project, repository, enabled = false, lastSync = None, lastFailed = None, links = None)
+}
 case class Repository(url: String, host: String, project: String, repository: String, enabled: Boolean, lastSync: Option[DateTime], lastFailed: Option[DateTime], links: Option[List[Link]])
 case class Ticket(name: String, href: String, links: Option[List[Link]])
 


### PR DESCRIPTION
Fixes #2 

Now the endpoint ```GET    /api/repos/:repositoryUrl``` will try to check with supported SCM, if the ```repositoryUrl``` can not be found in db